### PR TITLE
Phase 3.3 Step 15 — Module Catalog Contract + Service Skeleton

### DIFF
--- a/backend/src/modules/catalog/module-catalog.service.ts
+++ b/backend/src/modules/catalog/module-catalog.service.ts
@@ -1,0 +1,95 @@
+// backend/src/modules/catalog/module-catalog.service.ts
+
+import { Injectable } from "@nestjs/common";
+import type {
+  DeploymentTier,
+  ModuleCatalog,
+  ModuleCatalogEntry,
+  ModuleConfigFileDescriptor,
+  RawModuleConfigFile,
+  RawModuleDescriptor,
+} from "./module-catalog.types";
+
+/**
+ * ModuleCatalogService
+ *
+ * Structural normalization layer that converts raw loader module data into
+ * the canonical ModuleCatalogEntry format.
+ *
+ * NOTE (Step 15):
+ * - No loader bridge calls.
+ * - No filesystem or database access.
+ * - No HTTP endpoints.
+ * - No tier gating or filtering logic.
+ * - Pure structural mapping only.
+ */
+@Injectable()
+export class ModuleCatalogService {
+  /**
+   * Normalizes an array of raw modules into a ModuleCatalog.
+   */
+  normalizeCatalog(rawModules: RawModuleDescriptor[]): ModuleCatalog {
+    return rawModules.map((raw) => this.normalizeModule(raw));
+  }
+
+  /**
+   * Normalizes a single raw module descriptor into a ModuleCatalogEntry.
+   */
+  normalizeModule(raw: RawModuleDescriptor): ModuleCatalogEntry {
+    const displayName = raw.displayName ?? raw.name;
+    const tags = Array.isArray(raw.tags) ? raw.tags.slice() : [];
+    const tier = this.normalizeTier(raw.tier);
+    const configFiles = this.normalizeConfigFiles(raw.id, raw.configFiles ?? []);
+
+    return {
+      id: raw.id,
+      name: raw.name,
+      displayName,
+      description: raw.description,
+      version: raw.version,
+      tier,
+      configFiles,
+      tags,
+      raw,
+    };
+  }
+
+  /**
+   * Normalizes the list of config files for a module.
+   *
+   * This performs only simple structural mapping, with no validation or
+   * schema awareness.
+   */
+  normalizeConfigFiles(
+    moduleId: string,
+    rawFiles: RawModuleConfigFile[],
+  ): ModuleConfigFileDescriptor[] {
+    return rawFiles.map((file, index) => {
+      const id = `${moduleId}:config:${index.toString(10)}`;
+
+      const descriptor: ModuleConfigFileDescriptor = {
+        id,
+        path: file.path,
+        format: file.format,
+        required: file.required === true,
+        description: file.description,
+        metadata: file.metadata,
+      };
+
+      return descriptor;
+    });
+  }
+
+  /**
+   * Internal helper: normalize tier strings into a DeploymentTier.
+   *
+   * No gating or filtering is performed; unknown values are treated as "mvp"
+   * by default for now, keeping behavior simple.
+   */
+  private normalizeTier(tier: string | undefined): DeploymentTier {
+    if (tier === "premium") {
+      return "premium";
+    }
+    return "mvp";
+  }
+}

--- a/backend/src/modules/catalog/module-catalog.types.ts
+++ b/backend/src/modules/catalog/module-catalog.types.ts
@@ -1,0 +1,136 @@
+// backend/src/modules/catalog/module-catalog.types.ts
+
+/**
+ * Deployment tier for modules.
+ *
+ * - "mvp"     → available in the base tier
+ * - "premium" → available only in premium tier (metadata-only at this stage)
+ */
+export type DeploymentTier = "mvp" | "premium";
+
+/**
+ * Raw representation of a module config file as produced by the loader layer.
+ *
+ * This mirrors the shape coming from Phase 2 / the schema loader,
+ * and may contain loader-specific details. It is NOT normalized and
+ * may differ across loader implementations.
+ */
+export interface RawModuleConfigFile {
+  /** Path relative to the module root, e.g. "config/default.json" */
+  path: string;
+
+  /** Optional human-readable description. */
+  description?: string;
+
+  /** Format identifier, e.g. "json", "yaml", etc. */
+  format: string;
+
+  /** Optional flag indicating if this file is required by the module. */
+  required?: boolean;
+
+  /** Arbitrary metadata passed through from the loader. */
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * Raw representation of a module descriptor as produced by the loader layer.
+ *
+ * This is the direct contract from Phase 2 to Phase 3 before normalization.
+ */
+export interface RawModuleDescriptor {
+  /** Unique identifier for the module within the loader ecosystem. */
+  id: string;
+
+  /** Canonical module name (may be the same as id). */
+  name: string;
+
+  /** Optional human-friendly display name. */
+  displayName?: string;
+
+  /** Optional description copy. */
+  description?: string;
+
+  /** Optional semver-like version string. */
+  version?: string;
+
+  /** Optional tier identifier, passthrough from loader. */
+  tier?: string;
+
+  /** Optional list of tags or keywords. */
+  tags?: string[];
+
+  /** Raw config file descriptors, straight from the loader. */
+  configFiles?: RawModuleConfigFile[];
+
+  /** Loader-specific metadata, kept opaque to the catalog. */
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * Normalized representation of a single configuration file for a module.
+ *
+ * This type is the internal, backend-facing view of a config file,
+ * derived from RawModuleConfigFile.
+ */
+export interface ModuleConfigFileDescriptor {
+  /** Stable identifier for this config file within the module. */
+  id: string;
+
+  /** Path relative to the module root, e.g. "config/default.json". */
+  path: string;
+
+  /** Format identifier, e.g. "json", "yaml", etc. */
+  format: string;
+
+  /** True if this file is required for the module to function. */
+  required: boolean;
+
+  /** Optional human-readable description. */
+  description?: string;
+
+  /** Opaque metadata carried over from the raw descriptor. */
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * Canonical catalog entry for a single module within the backend.
+ *
+ * This is the primary type the rest of the backend should consume when
+ * working with modules (listing, selection, etc.).
+ */
+export interface ModuleCatalogEntry {
+  /** Stable module identifier. */
+  id: string;
+
+  /** Canonical module name. */
+  name: string;
+
+  /** Human-facing display name (falls back to name if missing). */
+  displayName: string;
+
+  /** Optional description describing the module. */
+  description?: string;
+
+  /** Optional version string. */
+  version?: string;
+
+  /** Deployment tier for this module. */
+  tier: DeploymentTier;
+
+  /** Normalized config files associated with this module. */
+  configFiles: ModuleConfigFileDescriptor[];
+
+  /** Optional tags or keywords. */
+  tags: string[];
+
+  /**
+   * The original raw descriptor as produced by the loader layer.
+   * Kept for debugging and advanced use cases.
+   */
+  raw: RawModuleDescriptor;
+}
+
+/**
+ * A module catalog is simply a list of modules.
+ */
+export type ModuleCatalog = ModuleCatalogEntry[];

--- a/backend/src/modules/modules.module.ts
+++ b/backend/src/modules/modules.module.ts
@@ -1,0 +1,33 @@
+// backend/src/modules/modules.module.ts
+
+import { Module } from "@nestjs/common";
+import { ModulesController } from "./modules.controller";
+import { ModulesService } from "./modules.service";
+import { ModuleDiscoveryService } from "./module-discovery.service";
+import { ModuleCatalogService } from "./catalog/module-catalog.service";
+
+/**
+ * ModulesModule
+ *
+ * Aggregates services and controllers related to module discovery,
+ * catalog normalization, and module listing.
+ *
+ * NOTE (Step 15):
+ * - ModuleCatalogService is registered as a provider and exported.
+ * - No loader bridge or DB wiring is added here.
+ */
+@Module({
+  imports: [],
+  controllers: [ModulesController],
+  providers: [
+    ModulesService,
+    ModuleDiscoveryService,
+    ModuleCatalogService,
+  ],
+  exports: [
+    ModulesService,
+    ModuleDiscoveryService,
+    ModuleCatalogService,
+  ],
+})
+export class ModulesModule {}


### PR DESCRIPTION
# Phase 3 — Task 3.3 — Step 15 Pull Request

## 📝 Summary
Introduces the foundational Module Catalog domain layer for GCD, including the canonical TypeScript types representing modules and the initial skeleton of the ModuleCatalogService. This establishes the internal structure required for schema-loader integration in future steps, without adding any loader, DB, or HTTP functionality.

## 📁 Files Added / Modified
- `backend/src/modules/catalog/module-catalog.types.ts` (created)
- `backend/src/modules/catalog/module-catalog.service.ts` (created)
- `backend/src/modules/modules.module.ts` (created or updated to register the new service)

## 🎯 Purpose
This step defines the contract for how module metadata will be represented internally in GCD. It provides:
- A strongly typed domain model for module descriptors.
- A normalization service that converts raw loader output into a stable internal format.
- A clean architectural boundary for future schema-driven behavior (Phase 3.3+).

This step **does not** introduce logic beyond structural normalization.

## ✔ Behavior Implemented
- Added the DeploymentTier type and full module schema domain types.
- Added ModuleCatalogService with normalization skeleton:
  - normalizeCatalog(rawModules)
  - normalizeModule(raw)
  - normalizeConfigFiles(moduleId, rawFiles)
  - normalizeTier(tier)
- No loader integration, no HTTP endpoints, no DB operations.
- ModulesModule updated to register and export ModuleCatalogService.
- All TypeScript compiles with 0 errors.

## 🔧 Notes / Future Enhancements
- Tier metadata and capabilities are passed through but not acted upon.
- Loader bridge integration will occur in a future step.
- ModuleCatalogService will become central to Module listing, configuration flows, and UI exposure.

## 🔗 Main Brain Approval
Step 15 has been reviewed and approved by Chief Engineer.
