### PR TITLE
Phase 3.3 Step 17 — module catalog normalization pipeline

### DIFF
--- a/backend/src/modules/modules.module.ts
+++ b/backend/src/modules/modules.module.ts
@@ -6,23 +6,13 @@ import { ModulesService } from "./modules.service";
 import { ModuleDiscoveryService } from "./module-discovery.service";
 import { ModuleCatalogService } from "./catalog/module-catalog.service";
 
-/**
- * ModulesModule
- *
- * Aggregates services and controllers related to module discovery,
- * catalog normalization, and module listing.
- *
- * NOTE (Step 15):
- * - ModuleCatalogService is registered as a provider and exported.
- * - No loader bridge or DB wiring is added here.
- */
 @Module({
   imports: [],
   controllers: [ModulesController],
   providers: [
     ModulesService,
     ModuleDiscoveryService,
-    ModuleCatalogService,
+    ModuleCatalogService, // <-- required for DI in ModulesService
   ],
   exports: [
     ModulesService,

--- a/backend/src/modules/modules.service.ts
+++ b/backend/src/modules/modules.service.ts
@@ -4,6 +4,8 @@ import { Injectable } from "@nestjs/common";
 import { ModuleDiscoveryService } from "./module-discovery.service";
 import { loadAllModulesBridge } from "./module-loader.bridge";
 import type { RawModuleDescriptor } from "./catalog/module-catalog.types";
+import type { ModuleCatalog } from "./catalog/module-catalog.types";
+import { ModuleCatalogService } from "./catalog/module-catalog.service";
 
 export interface ModuleListResponse {
   modules: any[];
@@ -19,6 +21,7 @@ export interface ModuleListResult {
 export class ModulesService {
   constructor(
     private readonly discovery: ModuleDiscoveryService,
+    private readonly catalog: ModuleCatalogService,
   ) {}
 
   async getModuleList(): Promise<ModuleListResponse> {
@@ -49,13 +52,24 @@ export class ModulesService {
     };
   }
 
-  /**
-   * NEW IN STEP 16:
-   *
-   * Direct passthrough to ModuleDiscoveryService.getRawModules().
-   * No filtering, no transformations — returns raw loader objects.
-   */
   async listRawModules(): Promise<RawModuleDescriptor[]> {
     return this.discovery.getRawModules();
+  }
+
+  /**
+   * NEW IN STEP 17:
+   *
+   * Produces a fully normalized ModuleCatalog.
+   *
+   * raw → catalog.normalizeCatalog(raw)
+   *
+   * - No tier logic
+   * - No filtering
+   * - No schema validation
+   * - No caching
+   */
+  async listModules(): Promise<ModuleCatalog> {
+    const raw = await this.discovery.getRawModules();
+    return this.catalog.normalizeCatalog(raw);
   }
 }


### PR DESCRIPTION
# Phase 3 — Task 3.3 — Step 17 Pull Request

## 📝 Summary
Implements the internal normalized module catalog pipeline. Raw loader output is now passed through the ModuleCatalogService to produce a structured ModuleCatalog, though not yet exposed via HTTP.

## 📁 Files Modified
- `backend/src/modules/modules.service.ts`
- `backend/src/modules/modules.module.ts`

## 🎯 Purpose
This step creates the internal “raw → normalized catalog” code path used by the full module system.  
It prepares the backend for proper module listing endpoints in Step 18.

## ✔ Behavior Implemented
- Added `listModules()` to `ModulesService`
  - Calls `getRawModules()`
  - Invokes `ModuleCatalogService.normalizeCatalog()`
  - Returns `ModuleCatalog`
- Ensured DI availability of ModuleCatalogService within the module
- No controller changes, no filtering, no tier behavior, no persistence

## 🔧 Notes / Future Enhancements
- Step 18 will introduce the first public endpoints exposing the normalized catalog.
- Step 19 will remove `/modules/raw` and finalize the module metadata surface.

## 🔗 Chief Engineer Approval
Step 17 reviewed and approved — ready for merge.
