### PR TITLE
Phase 3.3 Step 19 — finalize module API surface and remove debug endp…

### DIFF
--- a/backend/src/modules/modules.controller.ts
+++ b/backend/src/modules/modules.controller.ts
@@ -3,44 +3,25 @@
 import { Controller, Get } from "@nestjs/common";
 import { ModulesService } from "./modules.service";
 import type { ModuleCatalog } from "./catalog/module-catalog.types";
-import type { RawModuleDescriptor } from "./catalog/module-catalog.types";
 
 /**
  * ModulesController
  *
- * STEP 18:
- *  - GET /modules now returns the *normalized catalog*
- *    produced by ModulesService.listModules().
- *
- * NOTE:
- *  - GET /modules/raw remains intact for debugging
- *    until Step 19 instructs us to remove it.
+ * STEP 19:
+ *  - Debug endpoint `/modules/raw` has been removed.
+ *  - Only the production-grade normalized endpoint remains:
+ *        GET /modules
  */
 @Controller("modules")
 export class ModulesController {
   constructor(private readonly modulesService: ModulesService) {}
 
   /**
-   * NEW IN STEP 18
-   *
-   * Returns the normalized ModuleCatalog:
-   *   raw → ModuleCatalogService.normalizeCatalog(raw)
-   *
-   * This is now the primary public module listing endpoint.
+   * GET /modules
+   * Returns normalized module catalog.
    */
   @Get()
   async listCatalog(): Promise<ModuleCatalog> {
     return this.modulesService.listModules();
-  }
-
-  /**
-   * DEBUG ENDPOINT (kept temporarily until Step 19)
-   *
-   * Returns raw loader output exactly as produced by the bridge.
-   * No normalization or processing.
-   */
-  @Get("raw")
-  async listRaw(): Promise<RawModuleDescriptor[]> {
-    return this.modulesService.listRawModules();
   }
 }

--- a/backend/src/modules/modules.module.ts
+++ b/backend/src/modules/modules.module.ts
@@ -6,13 +6,20 @@ import { ModulesService } from "./modules.service";
 import { ModuleDiscoveryService } from "./module-discovery.service";
 import { ModuleCatalogService } from "./catalog/module-catalog.service";
 
+/**
+ * ModulesModule
+ *
+ * STEP 19:
+ * - No debug controllers remain.
+ * - No wiring changes beyond ensuring ModulesController is still registered.
+ */
 @Module({
   imports: [],
   controllers: [ModulesController],
   providers: [
     ModulesService,
     ModuleDiscoveryService,
-    ModuleCatalogService, // <-- required for DI in ModulesService
+    ModuleCatalogService,
   ],
   exports: [
     ModulesService,

--- a/backend/src/modules/modules.service.ts
+++ b/backend/src/modules/modules.service.ts
@@ -52,21 +52,9 @@ export class ModulesService {
     };
   }
 
-  async listRawModules(): Promise<RawModuleDescriptor[]> {
-    return this.discovery.getRawModules();
-  }
-
   /**
-   * NEW IN STEP 17:
-   *
-   * Produces a fully normalized ModuleCatalog.
-   *
-   * raw → catalog.normalizeCatalog(raw)
-   *
-   * - No tier logic
-   * - No filtering
-   * - No schema validation
-   * - No caching
+   * STEP 17:
+   * Returns the fully normalized ModuleCatalog.
    */
   async listModules(): Promise<ModuleCatalog> {
     const raw = await this.discovery.getRawModules();


### PR DESCRIPTION
# Phase 3 — Task 3.3 — Step 19 Pull Request

## 📝 Summary
Removes the temporary `/modules/raw` debug endpoint and finalizes the public module API surface. Ensures `GET /modules` is the sole exposed module catalog route.

## 📁 Files Modified
- `backend/src/modules/modules.controller.ts`
- `backend/src/modules/modules.service.ts`
- `backend/src/modules/modules.module.ts`

## 🎯 Purpose
Completes the cleanup of debug infrastructure added during catalog development. This makes the module API production-safe and prepares the system for future config application workflows.

## ✔ Behavior Implemented
- Removed `GET /modules/raw`
- Removed unused `listRawModules()` from ModulesService
- Ensured ModulesController exposes only the normalized catalog endpoint
- Verified DI wiring and module structure remain intact
- Zero TypeScript errors

## 🔧 Notes / Future Enhancements
- Task 3.4 will introduce config-application logic and schema-driven config handling.

## 🔗 Chief Engineer Approval
Step 19 approved — ready for merge.
