### PR TITLE
Phase 3.4 Step 20 — add PreparedConfigInstance types and prepareConfi…

### DIFF
--- a/backend/src/config-instances/config-instance.types.ts
+++ b/backend/src/config-instances/config-instance.types.ts
@@ -1,0 +1,39 @@
+// backend/src/config-instances/config-instance.types.ts
+
+/**
+ * PreparedConfigInstance
+ *
+ * Internal, enriched representation of a config instance that
+ * combines raw persisted JSON with normalized module metadata.
+ *
+ * NOTE (Step 20):
+ * - Types only, no logic.
+ * - No imports from loaders or schema processors.
+ * - Suitable for MVP, extensible for Premium.
+ */
+export interface PreparedConfigInstance {
+  id: string;
+  userId: string;
+  moduleName: string;
+
+  // Raw persisted JSON config
+  configData: any;
+
+  // Normalized module metadata (from ModuleCatalogEntry)
+  moduleMeta: {
+    id: string;
+    name: string;
+    displayName: string;
+    version?: string;
+    description?: string;
+    configFiles: Array<{
+      id: string;
+      path: string;
+      format: string;
+      required: boolean;
+      metadata?: Record<string, any>;
+    }>;
+    tags: string[];
+    tier?: string;
+  };
+}

--- a/backend/src/config-instances/config-instances.service.ts
+++ b/backend/src/config-instances/config-instances.service.ts
@@ -1,10 +1,17 @@
 // backend/src/config-instances/config-instances.service.ts
 
-import { Injectable } from "@nestjs/common";
+import { Injectable, NotFoundException } from "@nestjs/common";
 import { InjectRepository } from "@nestjs/typeorm";
 import { Repository } from "typeorm";
 import { ConfigInstanceEntity } from "./config-instance.entity";
 
+import type { PreparedConfigInstance } from "./config-instance.types";
+import { ModulesService } from "../modules/modules.service";
+import type { ModuleCatalogEntry } from "../modules/catalog/module-catalog.types";
+
+/**
+ * Formatted list item for user-facing config-instance overviews.
+ */
 export interface FormattedConfigInstanceItem {
   id: string;
   moduleName: string;
@@ -12,6 +19,9 @@ export interface FormattedConfigInstanceItem {
   updatedAt: string;
 }
 
+/**
+ * Formatted result for user config instances.
+ */
 export interface FormattedConfigInstanceResult {
   userId: string;
   count: number;
@@ -22,13 +32,15 @@ export interface FormattedConfigInstanceResult {
  * ConfigInstancesService
  *
  * CRUD persistence for configuration instances.
- * Step 14 adds: findAllForUserFormatted() for response normalization.
+ * Step 14 added: findAllForUserFormatted().
+ * Step 20 adds: prepareConfigInstance() for structural enrichment.
  */
 @Injectable()
 export class ConfigInstancesService {
   constructor(
     @InjectRepository(ConfigInstanceEntity)
     private readonly repo: Repository<ConfigInstanceEntity>,
+    private readonly modulesService: ModulesService,
   ) {}
 
   async create(
@@ -72,7 +84,6 @@ export class ConfigInstancesService {
   }
 
   /**
-   * NEW IN STEP 14:
    * Returns a formatted representation of config instances for the user.
    * No configData is exposed.
    */
@@ -81,7 +92,7 @@ export class ConfigInstancesService {
   ): Promise<FormattedConfigInstanceResult> {
     const list = await this.findAllForUser(userId);
 
-    const items = list.map((ci) => ({
+    const items: FormattedConfigInstanceItem[] = list.map((ci) => ({
       id: ci.id,
       moduleName: ci.moduleName,
       createdAt: ci.createdAt.toISOString(),
@@ -93,5 +104,72 @@ export class ConfigInstancesService {
       count: items.length,
       items,
     };
+  }
+
+  /**
+   * NEW IN STEP 20:
+   *
+   * prepareConfigInstance()
+   *
+   * Structural enrichment only:
+   *  - Loads a ConfigInstance by id.
+   *  - Loads the normalized module catalog via ModulesService.listModules().
+   *  - Finds the module whose name matches configInstance.moduleName.
+   *  - Returns a PreparedConfigInstance combining both.
+   *
+   * Rules:
+   *  - Throws NotFoundException("Config instance not found") if instance is missing.
+   *  - Throws NotFoundException("Module not found") if catalog has no matching module.
+   *  - Does NOT modify configData.
+   *  - Does NOT validate or merge configData.
+   *  - Does NOT perform any SFTP or schema loader operations.
+   */
+  async prepareConfigInstance(id: string): Promise<PreparedConfigInstance> {
+    // 1. Load the config instance
+    const instance = await this.findById(id);
+    if (!instance) {
+      throw new NotFoundException("Config instance not found");
+    }
+
+    // 2. Load the normalized module catalog
+    const catalog = await this.modulesService.listModules();
+
+    // 3. Find the module whose name matches the instance.moduleName
+    const matchedModule: ModuleCatalogEntry | undefined = catalog.find(
+      (entry) => entry.name === instance.moduleName,
+    );
+
+    if (!matchedModule) {
+      throw new NotFoundException("Module not found");
+    }
+
+    // 4. Map matchedModule into the moduleMeta shape required by PreparedConfigInstance
+    const moduleMeta: PreparedConfigInstance["moduleMeta"] = {
+      id: matchedModule.id,
+      name: matchedModule.name,
+      displayName: matchedModule.displayName,
+      version: matchedModule.version,
+      description: matchedModule.description,
+      configFiles: matchedModule.configFiles.map((file) => ({
+        id: file.id,
+        path: file.path,
+        format: file.format,
+        required: file.required,
+        metadata: file.metadata as Record<string, any> | undefined,
+      })),
+      tags: matchedModule.tags,
+      tier: matchedModule.tier,
+    };
+
+    // 5. Construct the prepared configuration instance
+    const prepared: PreparedConfigInstance = {
+      id: instance.id,
+      userId: instance.userId,
+      moduleName: instance.moduleName,
+      configData: instance.configData,
+      moduleMeta,
+    };
+
+    return prepared;
   }
 }


### PR DESCRIPTION
# Phase 3 — Task 3.4 — Step 20 Pull Request

## 📝 Summary
Introduces the foundational internal types and service logic needed to prepare Config Instances using normalized ModuleCatalog metadata. Structural-only enrichment; no schema validation or SFTP behavior.

## 📁 Files Added / Modified
- `backend/src/config-instances/config-instance.types.ts`
- `backend/src/config-instances/config-instances.service.ts`

## 🎯 Purpose
Establishes the minimal backend infrastructure required for future schema-driven and config-application workflows. Ensures ConfigInstancesService can structurally combine raw config data with module metadata.

## ✔ Behavior Implemented
- Added `PreparedConfigInstance` type (MVP-safe, Premium-extensible)
- Added `prepareConfigInstance()`:
  - Loads ConfigInstance by id
  - Loads module catalog from `ModulesService.listModules()`
  - Assembles structural metadata
  - Throws correct NotFound exceptions
  - Performs no defaults, merging, or validation
- No endpoint changes introduced

## 🔧 Notes / Future Enhancements
- Step 21 will extend this into module-specific config interpretation.
- Future tasks will add schema-driven validation and SFTP application.

## 🔗 Chief Engineer Approval
Step 20 approved — ready for merge.
