### PR TITLE
Phase 3.4 Step 21 — add config file mapping types and structural mapC…

### DIFF
--- a/backend/src/config-instances/config-file-mapping.types.ts
+++ b/backend/src/config-instances/config-file-mapping.types.ts
@@ -1,0 +1,26 @@
+// backend/src/config-instances/config-file-mapping.types.ts
+
+/**
+ * Internal structural representation of a module config file binding.
+ *
+ * NOTE (Step 21):
+ * - Types only, no logic.
+ * - These do NOT represent file contents, only structural descriptors.
+ */
+export interface ConfigFileBinding {
+  fileId: string; // from moduleCatalog.configFiles.id
+  path: string;
+  format: string;
+  required: boolean;
+  metadata?: Record<string, any>;
+}
+
+/**
+ * Represents the full config-file mapping between a ConfigInstance
+ * and its module’s declared config files.
+ */
+export interface InstanceFileMapping {
+  configInstanceId: string;
+  moduleName: string;
+  files: ConfigFileBinding[];
+}


### PR DESCRIPTION
# Phase 3 — Task 3.4 — Step 21 Pull Request

## 📝 Summary
Introduces the structural mapping layer that associates ConfigInstances with their module-declared config files. No validation or schema behavior; structural metadata only.

## 📁 Files Added / Modified
- `backend/src/config-instances/config-file-mapping.types.ts`
- `backend/src/config-instances/config-instances.service.ts`

## 🎯 Purpose
Prepare backend internals for future config editing, validation, and SFTP application by establishing a formal mapping between instances and module config file definitions.

## ✔ Behavior Implemented
- Added ConfigFileBinding and InstanceFileMapping types
- Added `mapConfigFiles(id)`:
  - Loads config instance
  - Loads normalized module catalog
  - Locates matching module
  - Returns structural mapping of config files (no validation/merging)
- No endpoints added

## 🔧 Notes / Future Enhancements
- Step 22 will introduce structural content-binding (empty-content surface)
- No schema loader, no validation, no SFTP logic yet

## 🔗 Chief Engineer Approval
Step 21 approved — ready for merge.
