### PR TITLE
Phase 3.4 Step 22 — add config content surface types and buildContent…

### DIFF
--- a/backend/src/config-instances/config-content-surface.types.ts
+++ b/backend/src/config-instances/config-content-surface.types.ts
@@ -1,0 +1,28 @@
+// backend/src/config-instances/config-content-surface.types.ts
+
+/**
+ * Structural representation of module config-file content bindings.
+ *
+ * STEP 22:
+ * - `content` MUST always be `null`.
+ * - No file reading, no validation, no merging.
+ * - This prepares the backend for later content operations.
+ */
+export interface ConfigFileContentSurface {
+  fileId: string;        // Same ID from config-file mapping
+  path: string;          // Same path as the module config file descriptor
+  format: string;        // e.g. "json", "yaml"
+  required: boolean;     // Whether the config file is required by the module
+  content: any | null;   // ALWAYS null in Step 22
+  metadata?: Record<string, any>;
+}
+
+/**
+ * Represents the content surface for a config instance:
+ * a list of config-file bindings with placeholder `null` content.
+ */
+export interface InstanceContentSurface {
+  configInstanceId: string;
+  moduleName: string;
+  files: ConfigFileContentSurface[];
+}


### PR DESCRIPTION
# Phase 3 — Task 3.4 — Step 22 Pull Request

## 📝 Summary
Introduces the structural “content surface” layer that binds module config files to placeholder content (always null in Step 22). This prepares the backend for upcoming content operations without performing validation, merging, or file IO.

## 📁 Files Added / Modified
- `backend/src/config-instances/config-content-surface.types.ts`
- `backend/src/config-instances/config-instances.service.ts`

## 🎯 Purpose
Provide internal scaffolding for future config editing and SFTP application by defining stable structural entities for config file content association.

## ✔ Behavior Implemented
- Added `ConfigFileContentSurface` and `InstanceContentSurface` types.
- Added `buildContentSurface(id)` method:
  - Loads config instance and module metadata
  - Produces structural content bindings with `content: null`
  - No reading, parsing, or validation
- No endpoints added.

## 🔧 Notes / Future Enhancements
- Step 23 will introduce simulated SFTP application pipeline
- Content remains null until schema parsing is implemented in Phase 4

## 🔗 Chief Engineer Approval
Step 22 approved — ready for merge.
