### PR TITLE
Phase 3.4 Step 23 — add simulated apply pipeline and structural apply…

### DIFF
--- a/backend/src/config-instances/config-apply-sim.types.ts
+++ b/backend/src/config-instances/config-apply-sim.types.ts
@@ -1,0 +1,31 @@
+// backend/src/config-instances/config-apply-sim.types.ts
+
+/**
+ * Represents a structural placeholder for a file that would be applied
+ * during a real configuration deployment.
+ *
+ * STEP 23:
+ * - No real content.
+ * - No SFTP / filesystem interaction.
+ * - simulatedContent MUST always be null.
+ */
+export interface SimulatedAppliedFile {
+  fileId: string;
+  path: string;
+  format: string;
+  required: boolean;
+  metadata?: Record<string, any>;
+  simulatedContent: any | null; // ALWAYS null in Step 23
+}
+
+/**
+ * A purely structural placeholder describing the result of a simulated apply
+ * operation. No real application occurs.
+ */
+export interface SimulatedApplyResult {
+  configInstanceId: string;
+  moduleName: string;
+  files: SimulatedAppliedFile[];
+  status: "simulated";
+  message: string; // e.g. "Apply pipeline stub executed"
+}

--- a/backend/src/config-instances/config-instances.service.ts
+++ b/backend/src/config-instances/config-instances.service.ts
@@ -18,6 +18,10 @@ import type {
   ConfigFileContentSurface,
   InstanceContentSurface,
 } from "./config-content-surface.types";
+import type {
+  SimulatedAppliedFile,
+  SimulatedApplyResult,
+} from "./config-apply-sim.types";
 
 import { ModulesService } from "../modules/modules.service";
 import type { ModuleCatalogEntry } from "../modules/catalog/module-catalog.types";
@@ -227,6 +231,44 @@ export class ConfigInstancesService {
     return {
       configInstanceId: instance.id,
       moduleName: instance.moduleName,
+      files,
+    };
+  }
+
+  // ---------------------------
+  // SIMULATED APPLY PIPELINE (Step 23)
+  // ---------------------------
+
+  async simulateApply(id: string): Promise<SimulatedApplyResult> {
+    const instance = await this.findById(id);
+    if (!instance) {
+      throw new NotFoundException("Config instance not found");
+    }
+
+    const catalog = await this.modulesService.listModules();
+
+    const moduleEntry: ModuleCatalogEntry | undefined = catalog.find(
+      (m) => m.name === instance.moduleName,
+    );
+
+    if (!moduleEntry) {
+      throw new NotFoundException("Module not found");
+    }
+
+    const files: SimulatedAppliedFile[] = moduleEntry.configFiles.map((cf) => ({
+      fileId: cf.id,
+      path: cf.path,
+      format: cf.format,
+      required: cf.required,
+      metadata: cf.metadata as Record<string, any> | undefined,
+      simulatedContent: null, // ALWAYS null in Step 23
+    }));
+
+    return {
+      configInstanceId: instance.id,
+      moduleName: instance.moduleName,
+      status: "simulated",
+      message: "Apply pipeline stub executed",
       files,
     };
   }


### PR DESCRIPTION
# Phase 3 — Task 3.4 — Step 23 Pull Request

## 📝 Summary
Introduces the simulated apply pipeline, a structural precursor to the real future SFTP-backed apply logic. This step produces no side effects and performs no real file operations.

## 📁 Files Added / Modified
- `backend/src/config-instances/config-apply-sim.types.ts`
- `backend/src/config-instances/config-instances.service.ts`

## 🎯 Purpose
Create the stable, predictable structural shape that future apply logic will use. Ensures downstream systems (UI, SFTP layer, validators) have a consistent shape to build upon.

## ✔ Behavior Implemented
- `simulateApply(id)`:
  - Loads config instance and module metadata
  - Produces structural apply shape
  - Always returns `simulatedContent: null`
  - No validation, merging, or IO
- No endpoints added.

## 🔧 Notes / Future Enhancements
- Step 24 will introduce application exposure at the controller layer (still simulated).
- Real apply logic will be added in Phase 4/5.

## 🔗 Chief Engineer Approval
Step 23 approved — ready for merge.
