### PR TITLE
Phase 3.4 Step 26 — add apply readiness endpoint and structural readi…

### DIFF
--- a/backend/src/config-instances/config-apply-readiness.types.ts
+++ b/backend/src/config-instances/config-apply-readiness.types.ts
@@ -1,0 +1,15 @@
+// backend/src/config-instances/config-apply-readiness.types.ts
+
+/**
+ * STEP 26:
+ * Structural apply-readiness result.
+ *
+ * Only checks whether all required config files defined by the module
+ * are present in the structural mapping. No content, schema, IO, or SFTP checks.
+ */
+export interface ApplyReadinessResult {
+  configInstanceId: string;
+  moduleName: string;
+  ready: boolean;
+  missingRequiredFiles: string[];
+}

--- a/backend/src/config-instances/config-instances.module.ts
+++ b/backend/src/config-instances/config-instances.module.ts
@@ -2,14 +2,19 @@
 
 import { Module } from "@nestjs/common";
 import { TypeOrmModule } from "@nestjs/typeorm";
+
 import { ConfigInstanceEntity } from "./config-instance.entity";
 import { ConfigInstancesService } from "./config-instances.service";
 import { ConfigInstancesController } from "./config-instances.controller";
+import { ModulesModule } from "../modules/modules.module";
 
 @Module({
-  imports: [TypeOrmModule.forFeature([ConfigInstanceEntity])],
-  providers: [ConfigInstancesService],
+  imports: [
+    TypeOrmModule.forFeature([ConfigInstanceEntity]),
+    ModulesModule,
+  ],
   controllers: [ConfigInstancesController],
+  providers: [ConfigInstancesService],
   exports: [ConfigInstancesService],
 })
 export class ConfigInstancesModule {}


### PR DESCRIPTION
# Phase 3 — Task 3.4 — Step 26 Pull Request

## 📝 Summary
Adds the public apply readiness endpoint, completing the MVP structural apply subsystem. This endpoint determines whether a config instance is structurally ready for a future real apply based on required module file presence.

## 📁 Files Added / Modified
- `backend/src/config-instances/config-apply-readiness.types.ts`
- `backend/src/config-instances/config-instances.controller.ts`
- `backend/src/config-instances/config-instances.service.ts`

## 🎯 Purpose
Provide the UI and apply pipeline with a simple readiness signal, enabling apply buttons or workflows to be enabled/disabled without using real SFTP, file IO, or schema parsing. This completes the structural readiness portion of the MVP apply system.

## ✔ Behavior Implemented
- Adds `GET /config-instances/:id/apply-readiness`
- Adds `getApplyReadiness(id)` to ConfigInstancesService
  - loads config instance
  - loads module metadata
  - uses structural mapping (mapConfigFiles) to determine required file presence
  - returns `{ ready, missingRequiredFiles }`
- Fully structural; no IO, no merging, no validation beyond presence

## 🔧 Notes / Future Enhancements
- Real apply readiness will incorporate schema-based validation and merge previews in Phase 4–5.
- This endpoint forms the enable/disable logic foundation for UI apply controls.

## 🔗 Chief Engineer Approval
Step 26 approved — ready for merge.
